### PR TITLE
Add Audio Receive Functionality with Playback Support

### DIFF
--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -839,77 +839,55 @@ static AppSession_t * GetCreatePeerConnectionSession( AppContext_t * pAppContext
 static PeerConnectionResult_t HandleRxVideoFrame( void * pCustomContext,
                                                   PeerConnectionFrame_t * pFrame )
 {
-    #ifdef ENABLE_STREAMING_LOOPBACK
-    MediaFrame_t frame;
+    int32_t resultMedia = 0;
     AppContext_t * pAppContext = ( AppContext_t * ) pCustomContext;
+    MediaFrame_t frame;
 
     if( pFrame != NULL )
     {
         LogDebug( ( "Received video frame with length: %u", pFrame->dataLength ) );
 
+        memset( &frame, 0, sizeof( MediaFrame_t ) );
         frame.trackKind = TRANSCEIVER_TRACK_KIND_VIDEO;
         frame.pData = pFrame->pData;
         frame.size = pFrame->dataLength;
         frame.freeData = 0U;
         frame.timestampUs = pFrame->presentationUs;
-        if( pAppContext->pAppMediaSourcesContext->onMediaSinkHookFunc )
+        resultMedia = AppMediaSource_RecvFrame( pAppContext->pAppMediaSourcesContext,
+                                                &frame );
+        if( resultMedia != 0U )
         {
-            ( void ) pAppContext->pAppMediaSourcesContext->onMediaSinkHookFunc( pAppContext->pAppMediaSourcesContext->pOnMediaSinkHookCustom,
-                                                                                &frame );
+            LogInfo( ( "Dropping Rx video data with result: %ld", resultMedia ) );
         }
     }
-    #else /* ifdef ENABLE_STREAMING_LOOPBACK */
-    ( void ) pCustomContext;
-
-    if( pFrame != NULL )
-    {
-        LogDebug( ( "Received video frame with length: %u", pFrame->dataLength ) );
-    }
-    #endif /* ifdef ENABLE_STREAMING_LOOPBACK */
 
     return PEER_CONNECTION_RESULT_OK;
 }
 
-extern void AppMediaSourcePort_HandleReceiveFrame( MediaFrame_t * pFrame );
-
 static PeerConnectionResult_t HandleRxAudioFrame( void * pCustomContext,
                                                   PeerConnectionFrame_t * pFrame )
 {
-    #ifdef ENABLE_STREAMING_LOOPBACK
-    MediaFrame_t frame;
+    int32_t resultMedia = 0;
     AppContext_t * pAppContext = ( AppContext_t * ) pCustomContext;
+    MediaFrame_t frame;
 
     if( pFrame != NULL )
     {
         LogDebug( ( "Received audio frame with length: %u", pFrame->dataLength ) );
 
+        memset( &frame, 0, sizeof( MediaFrame_t ) );
         frame.trackKind = TRANSCEIVER_TRACK_KIND_AUDIO;
         frame.pData = pFrame->pData;
         frame.size = pFrame->dataLength;
         frame.freeData = 0U;
         frame.timestampUs = pFrame->presentationUs;
-        if( pAppContext->pAppMediaSourcesContext->onMediaSinkHookFunc )
+        resultMedia = AppMediaSource_RecvFrame( pAppContext->pAppMediaSourcesContext,
+                                                &frame );
+        if( resultMedia != 0U )
         {
-            ( void ) pAppContext->pAppMediaSourcesContext->onMediaSinkHookFunc( pAppContext->pAppMediaSourcesContext->pOnMediaSinkHookCustom,
-                                                                                &frame );
+            LogInfo( ( "Dropping Rx audio data with result: %ld", resultMedia ) );
         }
     }
-
-    #else /* ifdef ENABLE_STREAMING_LOOPBACK */
-    MediaFrame_t frame;
-    ( void ) pCustomContext;
-    if( pFrame != NULL )
-    {
-        LogDebug( ( "Received audio frame with length: %u", pFrame->dataLength ) );
-        memset( &frame, 0, sizeof( MediaFrame_t ) );
-
-        frame.pData = pFrame->pData;
-        frame.size = pFrame->dataLength;
-        frame.timestampUs = pFrame->presentationUs;
-        frame.trackKind = TRANSCEIVER_TRACK_KIND_AUDIO;
-        AppMediaSourcePort_HandleReceiveFrame( &frame );
-    }
-    #endif /* ifdef ENABLE_STREAMING_LOOPBACK */
 
     return PEER_CONNECTION_RESULT_OK;
 }

--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -856,7 +856,7 @@ static PeerConnectionResult_t HandleRxVideoFrame( void * pCustomContext,
                                                 &frame );
         if( resultMedia != 0U )
         {
-            LogInfo( ( "Dropping Rx video data with result: %ld", resultMedia ) );
+            LogDebug( ( "Dropping Rx video data with result: %ld", resultMedia ) );
         }
     }
 
@@ -884,7 +884,7 @@ static PeerConnectionResult_t HandleRxAudioFrame( void * pCustomContext,
                                                 &frame );
         if( resultMedia != 0U )
         {
-            LogInfo( ( "Dropping Rx audio data with result: %ld", resultMedia ) );
+            LogDebug( ( "Dropping Rx audio data with result: %ld", resultMedia ) );
         }
     }
 

--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -37,9 +37,7 @@
 #include "metric.h"
 #endif
 
-#ifdef ENABLE_STREAMING_LOOPBACK
 #include "app_media_source.h"
-#endif /* ifdef ENABLE_STREAMING_LOOPBACK */
 
 #if ENABLE_SCTP_DATA_CHANNEL
 #include "peer_connection_sctp.h"
@@ -872,6 +870,8 @@ static PeerConnectionResult_t HandleRxVideoFrame( void * pCustomContext,
     return PEER_CONNECTION_RESULT_OK;
 }
 
+extern void AppMediaSourcePort_HandleReceiveFrame( MediaFrame_t * pFrame );
+
 static PeerConnectionResult_t HandleRxAudioFrame( void * pCustomContext,
                                                   PeerConnectionFrame_t * pFrame )
 {
@@ -896,10 +896,18 @@ static PeerConnectionResult_t HandleRxAudioFrame( void * pCustomContext,
     }
 
     #else /* ifdef ENABLE_STREAMING_LOOPBACK */
+    MediaFrame_t frame;
     ( void ) pCustomContext;
     if( pFrame != NULL )
     {
         LogDebug( ( "Received audio frame with length: %u", pFrame->dataLength ) );
+        memset( &frame, 0, sizeof( MediaFrame_t ) );
+
+        frame.pData = pFrame->pData;
+        frame.size = pFrame->dataLength;
+        frame.timestampUs = pFrame->presentationUs;
+        frame.trackKind = TRANSCEIVER_TRACK_KIND_AUDIO;
+        AppMediaSourcePort_HandleReceiveFrame( &frame );
     }
     #endif /* ifdef ENABLE_STREAMING_LOOPBACK */
 

--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -36,7 +36,6 @@
 #if METRIC_PRINT_ENABLED
 #include "metric.h"
 #endif
-
 #include "app_media_source.h"
 
 #if ENABLE_SCTP_DATA_CHANNEL

--- a/examples/app_media_source/app_media_source.c
+++ b/examples/app_media_source/app_media_source.c
@@ -554,3 +554,30 @@ int32_t AppMediaSource_InitAudioTransceiver( AppMediaSourcesContext_t * pCtx,
 
     return ret;
 }
+
+int32_t AppMediaSource_RecvFrame( AppMediaSourcesContext_t * pCtx,
+                                  MediaFrame_t * pFrame )
+{
+    int32_t ret = 0;
+
+    if( ( pCtx == NULL ) || ( pFrame == NULL ) )
+    {
+        LogError( ( "Invalid input, pCtx: %p, pFrame: %p", pCtx, pFrame ) );
+        ret = -1;
+    }
+
+    if( ret == 0 )
+    {
+        #ifdef ENABLE_STREAMING_LOOPBACK
+            if( pCtx->onMediaSinkHookFunc )
+            {
+                ( void ) pCtx->onMediaSinkHookFunc( pCtx->pOnMediaSinkHookCustom,
+                                                    pFrame );
+            }
+        #else /* ifdef ENABLE_STREAMING_LOOPBACK */
+            AppMediaSourcePort_RecvFrame( pFrame );
+        #endif /* ifdef ENABLE_STREAMING_LOOPBACK */
+    }
+
+    return ret;
+}

--- a/examples/app_media_source/app_media_source.h
+++ b/examples/app_media_source/app_media_source.h
@@ -37,7 +37,8 @@ typedef int32_t (* AppMediaSourceOnMediaSinkHook)( void * pCustom,
 
 typedef struct AppMediaSourceContext
 {
-    MessageQueueHandler_t dataQueue;
+    MessageQueueHandler_t dataTxQueue;
+    MessageQueueHandler_t dataRxQueue;
     uint8_t numReadyPeer;
     TransceiverTrackKind_t trackKind;
 

--- a/examples/app_media_source/app_media_source.h
+++ b/examples/app_media_source/app_media_source.h
@@ -64,6 +64,8 @@ int32_t AppMediaSource_InitVideoTransceiver( AppMediaSourcesContext_t * pCtx,
                                              Transceiver_t * pVideoTranceiver );
 int32_t AppMediaSource_InitAudioTransceiver( AppMediaSourcesContext_t * pCtx,
                                              Transceiver_t * pAudioTranceiver );
+int32_t AppMediaSource_RecvFrame( AppMediaSourcesContext_t * pCtx,
+                                  MediaFrame_t * pFrame );
 
 #ifdef __cplusplus
 }

--- a/examples/app_media_source/app_media_source_port.h
+++ b/examples/app_media_source/app_media_source_port.h
@@ -44,6 +44,7 @@ int32_t AppMediaSourcePort_Start( OnFrameReadyToSend_t onVideoFrameReadyToSendFu
                                   void * pOnAudioFrameReadyToSendCustomContext );
 void AppMediaSourcePort_Stop( void );
 void AppMediaSourcePort_Destroy( void );
+void AppMediaSourcePort_HandleReceiveFrame( MediaFrame_t * pFrame );
 
 #ifdef __cplusplus
 }

--- a/examples/app_media_source/app_media_source_port.h
+++ b/examples/app_media_source/app_media_source_port.h
@@ -44,7 +44,7 @@ int32_t AppMediaSourcePort_Start( OnFrameReadyToSend_t onVideoFrameReadyToSendFu
                                   void * pOnAudioFrameReadyToSendCustomContext );
 void AppMediaSourcePort_Stop( void );
 void AppMediaSourcePort_Destroy( void );
-void AppMediaSourcePort_HandleReceiveFrame( MediaFrame_t * pFrame );
+void AppMediaSourcePort_RecvFrame( MediaFrame_t * pFrame );
 
 #ifdef __cplusplus
 }

--- a/examples/app_media_source/app_media_source_port.h
+++ b/examples/app_media_source/app_media_source_port.h
@@ -44,7 +44,7 @@ int32_t AppMediaSourcePort_Start( OnFrameReadyToSend_t onVideoFrameReadyToSendFu
                                   void * pOnAudioFrameReadyToSendCustomContext );
 void AppMediaSourcePort_Stop( void );
 void AppMediaSourcePort_Destroy( void );
-void AppMediaSourcePort_RecvFrame( MediaFrame_t * pFrame );
+void AppMediaSourcePort_PlayAudioFrame( MediaFrame_t * pFrame );
 
 #ifdef __cplusplus
 }

--- a/examples/app_media_source/port/ameba_pro2/ameba_pro2_media_port.c
+++ b/examples/app_media_source/port/ameba_pro2/ameba_pro2_media_port.c
@@ -48,6 +48,7 @@ extern int max_local_skb_num;
 extern int max_skb_buf_num;
 
 #define MEDIA_PORT_SKB_BUFFER_THRESHOLD ( 64 )
+#define MEDIA_PORT_WEBRTC_AUDIO_FRAME_SIZE ( 256 )
 
 #define VIDEO_QCIF  0
 #define VIDEO_CIF   1
@@ -357,14 +358,20 @@ static void * CreateModuleHook( void * parent )
 static void * NewModuleItemHook( void * p )
 {
     ( void ) p;
-    return NULL;
+
+    return ( void * ) pvPortMalloc( MEDIA_PORT_WEBRTC_AUDIO_FRAME_SIZE * 2 );
 }
 
 static void * DeleteModuleItemHook( void * p,
                                     void * d )
 {
     ( void ) p;
-    ( void ) d;
+
+    if( d != NULL )
+    {
+        vPortFree( d );
+    }
+
     return NULL;
 }
 

--- a/examples/demo_config/demo_config_template.h
+++ b/examples/demo_config/demo_config_template.h
@@ -80,6 +80,8 @@
 #if ( AUDIO_G711_MULAW + AUDIO_G711_ALAW + AUDIO_OPUS ) != 1
 #error only one of audio format should be set
 #endif
+/* Enable audio receive flow to deliver received audio frames to output. */
+#define MEDIA_PORT_ENABLE_AUDIO_RECV ( 1 )
 
 /* Video codec setting. */
 #define USE_VIDEO_CODEC_H264 1

--- a/examples/peer_connection/peer_connection_srtp.c
+++ b/examples/peer_connection/peer_connection_srtp.c
@@ -50,7 +50,6 @@
  */
 #define PEER_CONNECTION_SRTP_RTX_WRITE_RESERVED_BYTES ( 2 )
 #define PEER_CONNECTION_SRTP_RTP_PAYLOAD_MAX_LENGTH      ( 1200 )
-#define PEER_CONNECTION_SRTP_JITTER_BUFFER_TOLERENCE_TIME_SECOND ( 2 )
 
 /*-----------------------------------------------------------*/
 

--- a/examples/peer_connection/peer_connection_srtp.c
+++ b/examples/peer_connection/peer_connection_srtp.c
@@ -35,22 +35,6 @@
 #include "peer_connection_h265_helper.h"
 #include "peer_connection_opus_helper.h"
 
-/* At write frame, we reserve 2 bytes at the beginning of payload buffer for re-transmission if RTX is enabled. */
-/* The format of a retransmission packet is shown below:
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |                         RTP Header                            |
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |            OSN                |                               |
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
- |                  Original RTP Packet Payload                  |
- |                                                               |
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- */
-#define PEER_CONNECTION_SRTP_RTX_WRITE_RESERVED_BYTES ( 2 )
-#define PEER_CONNECTION_SRTP_RTP_PAYLOAD_MAX_LENGTH      ( 1200 )
-
 /*-----------------------------------------------------------*/
 
 static PeerConnectionResult_t OnJitterBufferFrameReady( void * pCustomContext,

--- a/examples/peer_connection/peer_connection_srtp.c
+++ b/examples/peer_connection/peer_connection_srtp.c
@@ -113,6 +113,19 @@ static PeerConnectionResult_t OnJitterBufferFrameDrop( void * pCustomContext,
 {
     PeerConnectionResult_t ret = PEER_CONNECTION_RESULT_OK;
 
+    if( pCustomContext == NULL )
+    {
+        LogError( ( "Invalid input, pCustomContext: %p", pCustomContext ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+
+    if( ret == PEER_CONNECTION_RESULT_OK )
+    {
+        LogDebug( ( "Dropping packets from start seq: %u to end seq: %u",
+                    startSequence,
+                    endSequence ) );
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
issue #, if available:
From https://github.com/awslabs/freertos-webrtc-reference-on-amebapro-for-amazon-kinesis-video-streams/issues/28, without this PR, we're not able to deliver audio frames to speaker even that's connected to the board.

Description of changes:
This PR implements audio receive (Rx) functionality for the implementation, enabling the application to receive and play audio frames from remote peers by following RTK reference in [freertos-kvs-LTS repository](https://github.com/Freertos-kvs-LTS/freertos-kvs-LTS/blob/main/component/example/kvs_webrtc_mmf/module_kvs_webrtc.c#L83-L110).

Audio Rx Task: Created a dedicated task to handle incoming audio frames and route them to the speaker for playback
Media Source Enhancement: Extended the app media source layer to properly handle and deliver received audio frames
Port Layer Updates: Modified media port to support audio frame processing in the receive path
Frame Delivery Pipeline: Implemented a complete pipeline from WebRTC reception to audio playback
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.